### PR TITLE
ApplyTheme was not exported.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,6 @@
  * @copyright 2015, Andrey Popp <8mayday@gmail.com>
  */
 
+export ApplyTheme         from './ApplyTheme';
 export Themeable          from './Themeable';
-export Themed             from './Themed';
 export {default as theme} from './themeComponent';


### PR DESCRIPTION
@andreypopp 

Since ApplyTheme was not exported, I had to reach in to grab it.

`import ApplyTheme from 'rethemeable/lib/ApplyTheme';`
vs
`import { ApplyTheme } from 'rethemeable';`
