### PR TITLE
Lowercased Themeable since it is a function and not a class.

### DIFF
--- a/src/__tests__/Themeable-test.js
+++ b/src/__tests__/Themeable-test.js
@@ -8,7 +8,7 @@ import expect               from 'expect';
 import React                from 'react';
 import TestUtils            from 'react/lib/ReactTestUtils';
 import {makeThemeContext}   from '../ThemeContextTypes';
-import Themeable            from '../Themeable';
+import themeable            from '../themeable';
 
 function shallowRender(element, context) {
   let renderer = TestUtils.createRenderer();
@@ -16,9 +16,9 @@ function shallowRender(element, context) {
   return renderer.getRenderOutput();
 }
 
-describe('<Themeable />', function() {
+describe('themeable()', function() {
 
-  @Themeable
+  @themeable
   class Component extends React.Component {
 
     static defaultTheme = {

--- a/src/__tests__/themeComponent-test.js
+++ b/src/__tests__/themeComponent-test.js
@@ -5,7 +5,7 @@
 import expect         from 'expect';
 import React          from 'react';
 import TestUtils      from 'react/lib/ReactTestUtils';
-import Themeable      from '../Themeable';
+import themeable      from '../themeable';
 import themeComponent from '../themeComponent';
 
 function shallowRender(element, context) {
@@ -19,7 +19,7 @@ describe('themeComponent', function() {
   it('works as factory', function() {
     let theme = {className: 'className'};
 
-    @Themeable
+    @themeable
     class Component extends React.Component {
 
       render() {
@@ -36,7 +36,7 @@ describe('themeComponent', function() {
   it('still allow theme override via props', function() {
     let theme = {className: 'className'};
 
-    @Themeable
+    @themeable
     class Component extends React.Component {
 
       render() {
@@ -53,7 +53,7 @@ describe('themeComponent', function() {
 
   it('merges with the previous theme', function() {
 
-    @Themeable
+    @themeable
     class Component extends React.Component {
 
       static defaultTheme = {className: 'className'};

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,5 @@
  */
 
 export ApplyTheme         from './ApplyTheme';
-export Themeable          from './Themeable';
+export themeable          from './themeable';
 export {default as theme} from './themeComponent';

--- a/src/themeable.js
+++ b/src/themeable.js
@@ -14,7 +14,7 @@ import themeComponent                       from './themeComponent';
  * Also themeable components have `theme` class attribute which is used to
  * distinguish component styles.
  */
-export default function Themeable(Component, defaultTheme) {
+export default function themeable(Component, defaultTheme) {
   let displayName = Component.displayName || Component.name;
   let themeKey = Symbol(displayName);
 


### PR DESCRIPTION
@andreypopp 

I am using AirBnB's eslint, which is quite strict, but it wont allow me to import and use Themeable directly.  So instead I have to:

```
import { Themeable as themeable } from 'rethemeable';
```

Makes sense though since Themeable is not something you `new` up.  It is a function that accepts and returns a Component.
