### PR TITLE
Removed Symbols since browser support is minimal.  Now just uses the displayName string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 5.0.0
 =====
 
-* Added support to pass in external Symbol when decorating a component with `themeable`
+* [ADDED] Added support to pass in external themeKey when decorating a component with `themeable`
+* [BREAKING] Removed Symbols for Universal support since browser support is minimal.  Now defaults to displayName string.
 * [BREAKING] Moved `defaultTheme` into an options object along with `themeKey`
 
-  Allowing an external Symbol to be passed for a given `themeable` component's `themeKey` enables the theme to be bundled/chunked separately from the component. This is particularly useful when splitting and chunking assets with CSS Modules.
+  Allowing an external key (Symbol, string, or other) to be passed in for a given `themeable` component's `themeKey`.  This enables the theme to be bundled/chunked separately from the component. This is particularly useful when splitting and chunking assets with CSS Modules.
 
 [4.1.0]
 =====

--- a/src/themeable.js
+++ b/src/themeable.js
@@ -18,7 +18,7 @@ import themeComponent from './themeComponent';
  */
 export default function themeable(Component, { defaultTheme, themeKey } = {}) {
   const displayName = Component.displayName || Component.name;
-  const themeableKey = typeof themeKey === 'symbol' ? themeKey : Symbol(displayName);
+  const themeableKey = themeKey || displayName;
 
   class ThemeableComponent extends Component {
 


### PR DESCRIPTION
We have decided to move away from using Symbol's as the component's key in the theme map.  It is very difficult to share Symbols on client and server in a universal application.  It is still possible to pass in a Symbol as the `themeKey` to `themeable` if that feature is still requested.

Obviously, it is now up to the developer to ensure no key name conflicts with components in the theme map.

Please let us know if there is concerns/issues.